### PR TITLE
Revert "fix: Stop can when the CANSocket destructor is called"

### DIFF
--- a/common/source/can_socket.cpp
+++ b/common/source/can_socket.cpp
@@ -22,8 +22,6 @@ CANSocket::CANSocket(CommonKeyPairs& config) {
 CANSocket::~CANSocket() {
 	if (IsConnected())
 		::close(can_socket_);
-
-	DeConfig();
 }
 
 error_condition	CANSocket::ReConfig(const CommonKeyPairs& config) {


### PR DESCRIPTION
Reverts luxianzi/rservices#2
DeConfig() is called in the outer layer，as follow：
https://github.com/luxianzi/rservices/blob/ed415d9552dc41f139560ac9b48d2a95ef665567/hal/source/robo_master_c620_device.cpp#L34
